### PR TITLE
docs: README.mdにvCluster CLIのインストール手順と基本操作を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 近年、複数の Kubernetes クラスタを運用するためのベストプラクティスが話題となり、それに伴う形で MCO (Multi-cluster Orchestrator) をはじめとしたマルチクラスタオーケストレーションツールが登場している。  
 代表的なツールとして以下のものがある。  
 
-   - [Karmada](https://karmada.io/)
-   - [kro](https://kro.run/)
-   - [GKE Multi-cluster Orchestrator](https://cloud.google.com/blog/products/containers-kubernetes/multi-cluster-orchestrator-for-cross-region-kubernetes-workloads?hl=en)
+    - [Karmada](https://karmada.io/)
+    - [kro](https://kro.run/)
+    - [GKE Multi-cluster Orchestrator](https://cloud.google.com/blog/products/containers-kubernetes/multi-cluster-orchestrator-for-cross-region-kubernetes-workloads?hl=en)
 
 ## Karmada
 
@@ -20,3 +20,84 @@
 ### vCluster とは？
 
 ![vcluster-component](https://www.vcluster.com/docs/assets/images/vcluster-architecture-ed041d884918b68c3aa11a6d3d65224c.png)
+
+### vCluster CLI をインストールする
+
+- Homebrew を使って vCluster をインストールする
+
+    ```shell
+    brew install loft-sh/tap/vcluster-experimental
+    ```
+
+### vCluster CLI 基本操作
+
+- 仮想クラスタの作成 (--connect=false を追加するとクラスタ作成後に kube context を変更しない)
+  
+    ```shell
+    vcluster create {{ cluster-name }} --namespace {{ namespace }} [--connect=false]
+    ```
+
+- 既存仮想クラスターの設定更新
+  
+    ```shell
+    vcluster create --upgrade {{ cluster-name }} -n {{ namespace }} -f vcluster.yaml
+    ```
+
+    - k3s 以外の distro を指定する
+
+        ```shell
+        vcluster create --upgrade {{ cluster-name }} -n {{ namespace }} --distro k0s
+        ```
+
+- 仮想クラスタへの接続
+
+    ```shell
+    vcluster connect {{ cluster-name }} --namespace {{ namespace }}
+    ```
+
+- 接続中の仮想クラスターへの接続を切断してホストクラスターに戻る
+  
+    ```shell
+    vcluster disconnect
+    ```
+
+- 仮想クラスター一覧
+  
+    ```shell
+    vcluster list
+    ```
+
+- 仮想クラスター削除
+    
+    ```shell
+    vcluster delete {{ cluster-name }} --namespace {{ namespace }}
+    ```
+
+## 検証
+
+### kind クラスタを作成する
+
+- kind コマンドを実行してクラスタを構築する
+
+    ```shell
+    kind create cluster --config config/kind-config.yaml
+    ```
+
+- kubectl コマンドで作成したクラスタを確認する  
+  今回はワーカノードを2つ作成する
+
+    ```shell
+    $ kubectl get nodes
+    NAME                 STATUS     ROLES           AGE   VERSION
+    kind-control-plane   NotReady   control-plane   70s   v1.33.1
+    kind-worker          NotReady   <none>          60s   v1.33.1
+    kind-worker2         NotReady   <none>          60s   v1.33.1
+    ```
+
+### vCluster をデプロイする
+
+- vCluster を kind で作成した Kubernetes クラスタにデプロイする
+
+    ```shell
+    vcluster create my-vcluster --namespace team-x --values vcluster.yaml
+    ```

--- a/config/kind-config.yaml
+++ b/config/kind-config.yaml
@@ -1,0 +1,44 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  # ingress port for nginx
+  - containerPort: 30080
+    hostPort: 80
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+  - containerPort: 30443
+    hostPort: 443
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+  # API service extension for cluster communication (v1.cluster.loft.sh)
+  - containerPort: 8443
+    hostPort: 8443
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+  # Webhook validation and enforcement (loft webhook)
+  - containerPort: 9443
+    hostPort: 9443
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+  # Management API for platform administration (v1.management.loft.sh)
+  - containerPort: 9444
+    hostPort: 9444
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+  # Prometheus metrics proxy for cost monitoring
+  - containerPort: 9090
+    hostPort: 9090
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+- role: worker
+- role: worker
+networking:
+  disableDefaultCNI: false


### PR DESCRIPTION
## 変更内容
This pull request adds comprehensive documentation and configuration for setting up and managing vCluster, including CLI usage instructions and a `kind` cluster configuration. The most important changes include updates to the `README.md` for detailed vCluster CLI instructions and the addition of a `kind` cluster configuration file with custom settings.
* [`config/kind-config.yaml`](diffhunk://#diff-a19c77531eac8f0268ce8435f669092aa8f07175422c0b3d57f32bb0c749e843R1-R44): Added a new `kind` cluster configuration file with custom settings, including node roles, extra port mappings for services like ingress and Prometheus, and Kubernetes API extensions for vCluster and Loft management.config: kind-config.yamlを新規作成し、Kubernetesクラスタの設定を定義

## 変更の種類
<!-- 該当するものにチェックを入れてください -->
- [ ] バグ修正
- [x] 新機能追加
- [ ] 破壊的変更
- [x] ドキュメント更新
- [ ] リファクタリング
- [ ] パフォーマンス改善
- [ ] テスト追加・修正

## 関連するイシュー
<!-- 関連するイシューがあれば記載 -->
Closes #3

## テスト方法
<!-- この変更をどのようにテストしたかを記載 -->

## チェックリスト
- [x] 自分でコードレビューを行った
- [ ] テストを追加・更新した
- [x] ドキュメントを更新した
- [ ] 変更がブレイキングチェンジでない、またはマイグレーションガイドを提供した
- [ ] CI/CDパイプラインが正常に動作することを確認した
