### PR TITLE
Vcluster config

### DIFF
--- a/manifest/nginx.yaml
+++ b/manifest/nginx.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-vc1
+  namespace: vc1
+spec:
+  selector:
+    app: nginx-vc1
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-vc1
+  namespace: vc1
+spec:
+  selector:
+    matchLabels:
+      app: nginx-vc1
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-vc1
+    spec:
+      containers:
+      - name: nginx-container
+        image: nginx:latest
+        ports:
+          - name: http
+            containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-vc1-ingress
+  namespace: vc1
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /vc1
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-vc1
+            port:
+              number: 80

--- a/vcluster/vcluster.yaml
+++ b/vcluster/vcluster.yaml
@@ -1,0 +1,14 @@
+---
+sync:
+  fromHost:
+    ingressClasses:
+      enabled: true
+  toHost:
+    ingresses:
+      enabled: true
+exportKubeConfig:
+  context: test-domain-context
+  server: https://test-domain.org
+  secret:
+    namespace: kubeconfig-secret-namespace
+    name: vc-test-domain


### PR DESCRIPTION
## 変更内容
<!-- このPRで何を変更したかを記載 -->
This pull request introduces Kubernetes configurations for deploying an NGINX application within a virtual cluster (`vcluster`). Key changes include the addition of a deployment, service, and ingress for the NGINX application, as well as synchronization settings for the virtual cluster.

### Kubernetes configurations for NGINX deployment:

* [`manifest/nginx.yaml`](diffhunk://#diff-c32cbd29edaf8ebd185870f9ea4ce40bb161f26788d288ae23cef678819ec624R1-R57): Added a deployment, service, and ingress configuration for the `nginx-vc1` application in the `vc1` namespace. The ingress includes a rewrite rule and routes traffic from the `/vc1` path to the service.

### Virtual cluster synchronization settings:

* [`vcluster/vcluster.yaml`](diffhunk://#diff-8fe211c6f42e4821d3929e544cd2aaa95d3a5fe317dc0b39d3f9d34957a401d9R1-R14): Configured synchronization between the host and virtual cluster for ingress classes and ingresses. Also added settings to export the kubeconfig for the virtual cluster, specifying the context, server, and secret details.

## 変更の種類
<!-- 該当するものにチェックを入れてください -->
- [ ] バグ修正
- [x] 新機能追加
- [ ] 破壊的変更
- [ ] ドキュメント更新
- [ ] リファクタリング
- [ ] パフォーマンス改善
- [ ] テスト追加・修正

## 関連するイシュー
<!-- 関連するイシューがあれば記載 -->
Closes #3

## テスト方法
<!-- この変更をどのようにテストしたかを記載 -->

## チェックリスト
- [x] 自分でコードレビューを行った
- [ ] テストを追加・更新した
- [x] ドキュメントを更新した
- [ ] 変更がブレイキングチェンジでない、またはマイグレーションガイドを提供した
- [ ] CI/CDパイプラインが正常に動作することを確認した

## スクリーンショット
<!-- UIに関する変更の場合、スクリーンショットを添付 -->

## 追加情報
<!-- レビューアーに伝えたい追加情報があれば記載 -->
